### PR TITLE
Read from process.env to see if the value has already been set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,10 +32,10 @@ function getCliEnv () {
   logger.debug(`default env: ${DEFAULT_ENV}`)
   logger.debug(`config key to check for env: ${DEVELOPMENT_ENVIRONMENT_KEY}`)
 
-  const configValue = config.get(DEVELOPMENT_ENVIRONMENT_KEY)
+  const configValue = process.env.AIO_CLI_ENV || config.get(DEVELOPMENT_ENVIRONMENT_KEY)
   logger.debug(`config key value set for env: ${configValue}`)
 
-  const value = process.env.AIO_CLI_ENV || configValue || DEFAULT_ENV
+  const value = configValue || DEFAULT_ENV
   const lcValue = value.toLowerCase()
 
   // no config key set, or not a supported env, we return the default env

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,8 @@ function getCliEnv () {
   logger.debug(`default env: ${DEFAULT_ENV}`)
   logger.debug(`config key to check for env: ${DEVELOPMENT_ENVIRONMENT_KEY}`)
 
+  // The env AIO_CLI_ENV must be read explicitly instead of via `config.get` to support the case where the var is set via webpack
+  // after being webpack()'d the following line will look like this => const configValue = "prod" || config.get(DEVELOPMENT_ENVIRONMENT_KEY)
   const configValue = process.env.AIO_CLI_ENV || config.get(DEVELOPMENT_ENVIRONMENT_KEY)
   logger.debug(`config key value set for env: ${configValue}`)
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function getCliEnv () {
   const configValue = config.get(DEVELOPMENT_ENVIRONMENT_KEY)
   logger.debug(`config key value set for env: ${configValue}`)
 
-  const value = configValue || DEFAULT_ENV
+  const value = process.env.AIO_CLI_ENV || configValue || DEFAULT_ENV
   const lcValue = value.toLowerCase()
 
   // no config key set, or not a supported env, we return the default env

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,6 +65,9 @@ describe('getCliEnv', () => {
 
   test('reads from process.env before aioConfig', () => {
     mockConfig.get.mockReturnValueOnce('some-invalid-env')
+    process.env.AIO_CLI_ENV = 'invalid-value'
+    expect(getCliEnv()).toEqual(DEFAULT_ENV)
+
     process.env.AIO_CLI_ENV = STAGE
     expect(getCliEnv()).toEqual(STAGE)
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -62,6 +62,15 @@ describe('getCliEnv', () => {
     mockConfig.get.mockReturnValueOnce('some-invalid-env')
     expect(getCliEnv()).toEqual(PROD)
   })
+
+  test('reads from process.env before aioConfig', () => {
+    mockConfig.get.mockReturnValueOnce('some-invalid-env')
+    process.env.AIO_CLI_ENV = STAGE
+    expect(getCliEnv()).toEqual(STAGE)
+
+    delete process.env.AIO_CLI_ENV
+    expect(getCliEnv()).toEqual(PROD)
+  })
 })
 
 describe('setCliEnv', () => {


### PR DESCRIPTION
## Description

To support webpack 'd action usage, we need to be able to set the value before the action is deployed.
Assuming the cli is running in a 'stage' environment, and packaging an action that should also run in a 'stage' environment, our webpack plugin does the following:

```
const { getCliEnv, DEFAULT_ENV } = require('@adobe/aio-lib-env')
const cli_env = getCliEnv()
```

and defines the plugin as
```
new webpack.DefinePlugin({'process.env.AIO_CLI_ENV': `"${cli_env}"`})
```
this in turn is processed while building the action, and the aio-lib-env line :
```
const configValue = process.env.AIO_CLI_ENV || config.get(DEVELOPMENT_ENVIRONMENT_KEY)
```
which after being webpack 'd, becomes
```
const configValue = "stage" || config.get(DEVELOPMENT_ENVIRONMENT_KEY)
```

## How Has This Been Tested?

With action code : 
```
const { getCliEnv, DEFAULT_ENV } = require('@adobe/aio-lib-env')
console.log('getCliEnv => ', getCliEnv())
```

... and a webpack-config.js in my action folder
```
const webpack = require('webpack')
const { getCliEnv, DEFAULT_ENV } = require('@adobe/aio-lib-env')

console.log('getCliEnv() returns => ', getCliEnv())
const cli_env = getCliEnv()
module.exports = {
  plugins: [
    new webpack.DefinePlugin({
      'process.env.AIO_CLI_ENV': `"${cli_env}"`
    })
  ]
}
```

running the cli command 
    `AIO_CLI_ENV=stage aio app run`

outputs ( during build-actions stage )
    `getCliEnv() returns =>  stage` 

log outputs ( when the action is invoked )
    `2021-03-31T22:42:13.258Z       stdout: getCliEnv =>  stage` 

also, putting the value in the .env file:

    AIO_CLI_ENV=stage

or adding to the local .aio file ...
```
"cli": {
    "env": "stage"
  }
```
and running

    aio app build --skip-static

outputs

    ⠇ Building actionsgetCliEnv() returns =>  stage


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
