### PR TITLE
Add support for runtime actions and TVM client to get env

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,22 +28,33 @@ const DEFAULT_ENV = PROD_ENV
  * @returns {string} the cli environment (prod, stage)
  */
 function getCliEnv () {
-  logger.debug(`supported envs: ${JSON.stringify(SUPPORTED_ENVS)}`)
-  logger.debug(`default env: ${DEFAULT_ENV}`)
-  logger.debug(`config key to check for env: ${DEVELOPMENT_ENVIRONMENT_KEY}`)
+  /* The global var AIO_ENV_IS_STAGE is expected to be set during build time via WEBPACK config */
+  /* eslint no-undef: 0 */
+  const stageEnv = (typeof AIO_ENV_IS_STAGE === 'undefined') ? false : AIO_ENV_IS_STAGE
+  logger.debug(`AIO_ENV_IS_STAGE value is ${stageEnv}`)
 
-  const configValue = config.get(DEVELOPMENT_ENVIRONMENT_KEY)
-  logger.debug(`config key value set for env: ${configValue}`)
+  if (stageEnv) {
+    logger.debug(`return env as ${STAGE_ENV}`)
+    // return stage env if AIO_ENV_IS_STAGE set during build time
+    return STAGE_ENV
+  } else {
+    // try to get env value from config
+    logger.debug(`supported envs: ${JSON.stringify(SUPPORTED_ENVS)}`)
+    logger.debug(`default env: ${DEFAULT_ENV}`)
+    logger.debug(`config key to check for env: ${DEVELOPMENT_ENVIRONMENT_KEY}`)
 
-  const value = configValue || DEFAULT_ENV
-  const lcValue = value.toLowerCase()
+    const configValue = config.get(DEVELOPMENT_ENVIRONMENT_KEY)
+    logger.debug(`config key value set for env: ${configValue}`)
 
-  // no config key set, or not a supported env, we return the default env
-  if (!SUPPORTED_ENVS.includes(lcValue)) {
-    return DEFAULT_ENV
+    const value = configValue || DEFAULT_ENV
+    const lcValue = value.toLowerCase()
+
+    // no config key set, or not a supported env, we return the default env
+    if (!SUPPORTED_ENVS.includes(lcValue)) {
+      return DEFAULT_ENV
+    }
+    return lcValue
   }
-
-  return lcValue
 }
 
 /**

--- a/test/index.webpack.test.js
+++ b/test/index.webpack.test.js
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+global.AIO_ENV_IS_STAGE = true
+const { getCliEnv } = require('../src')
+
+const STAGE = 'stage'
+
+test('getCliEnv to return stage as env', () => {
+  expect(getCliEnv()).toEqual(STAGE)
+})


### PR DESCRIPTION
Add support for runtime actions and TVM client to get env
Webpack config global var AIO_ENV_IS_STAGE will be used to switch to stage env else use default logic to return env.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

unit tests, manual tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
